### PR TITLE
Update GitHub workflow actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,9 +10,12 @@ on:
 jobs:
   build-and-push:
     name: Deploy Docker Image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+
     steps:
-      - uses: actions/checkout@v2
+      - name: Retrieve the source code
+        uses: actions/checkout@v3
+
       - name: Build and push
         uses: openzim/docker-publish-action@v8
         with:

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -8,9 +8,11 @@ env:
 
 jobs:
   check-qa:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - name: Retrieve source code
+        uses: actions/checkout@v3
+
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,14 @@ env:
 jobs:
   release:
     environment: release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+
     steps:
-      - uses: actions/checkout@v2
+      - name: Retrieve source code
+        uses: actions/checkout@v3
+
       - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
           architecture: x64


### PR DESCRIPTION
Necessary to avoid CI warnings because older actions depend on deprecated Node.js 12.