### PR TITLE
change icon flag from url to image blob

### DIFF
--- a/offliner-definition.json
+++ b/offliner-definition.json
@@ -32,7 +32,8 @@
       "maxLength": 80
     },
     "icon": {
-      "type": "url",
+      "type": "blob",
+      "kind": "image",
       "required": false,
       "title": "Icon",
       "description": "Custom Icon for your ZIM (URL). iFixit square logo otherwise"


### PR DESCRIPTION
## Rationale
See openzim/zimfarm#1576

## Changes
- change `icon` flag from url to image blob