### PR TITLE
rename length constraints to graphemes

### DIFF
--- a/offliner-definition.json
+++ b/offliner-definition.json
@@ -20,16 +20,16 @@
       "required": false,
       "title": "Title",
       "description": "Custom title for your ZIM. iFixIt homepage title otherwise",
-      "minLength": 1,
-      "maxLength": 30
+      "minGraphemes": 1,
+      "maxGraphemes": 30
     },
     "description": {
       "type": "string",
       "required": false,
       "title": "Description",
       "description": "Custom description for your ZIM. iFixIt homepage description (meta) otherwise",
-      "minLength": 1,
-      "maxLength": 80
+      "minGraphemes": 1,
+      "maxGraphemes": 80
     },
     "icon": {
       "type": "blob",


### PR DESCRIPTION
## Changes
- rename length constraints to end with graphemes (See openzim/zimfarm#1890)